### PR TITLE
feat!: getRecommend now returns List<Score> with X-API-Version: 2

### DIFF
--- a/src/main/java/io/gorse/gorse4j/Gorse.java
+++ b/src/main/java/io/gorse/gorse4j/Gorse.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 public class Gorse {
 
@@ -55,15 +56,41 @@ public class Gorse {
         return List.of(this.request("GET", this.endpoint + "/api/user/" + userId + "/feedback/" + feedbackType, null, Feedback[].class));
     }
 
+    /**
+     * Get recommendation for a user.
+     * @param userId User ID
+     * @return List of recommended item IDs
+     */
     public List<String> getRecommend(String userId) throws IOException {
         return List.of(this.request("GET", this.endpoint + "/api/recommend/" + userId, null, String[].class));
     }
 
+    /**
+     * Get recommendation with scores for a user.
+     * Uses X-API-Version: 2 header to return scores.
+     * @param userId User ID
+     * @return List of Score objects with item IDs and scores
+     */
+    public List<Score> getRecommendWithScores(String userId) throws IOException {
+        return List.of(this.requestWithHeaders("GET", this.endpoint + "/api/recommend/" + userId, null, Score[].class, 
+            Map.of("X-API-Version", "2")));
+    }
+
     private <Request, Response> Response request(String method, String url, Request request, Class<Response> responseClass) throws IOException {
+        return requestWithHeaders(method, url, request, responseClass, null);
+    }
+
+    private <Request, Response> Response requestWithHeaders(String method, String url, Request request, Class<Response> responseClass, Map<String, String> headers) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
         connection.setRequestMethod(method);
         connection.setRequestProperty("X-API-Key", this.apiKey);
         connection.setRequestProperty("Content-Type", "application/json");
+        // Add custom headers
+        if (headers != null) {
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                connection.setRequestProperty(entry.getKey(), entry.getValue());
+            }
+        }
         // Send request
         ObjectMapper mapper = new ObjectMapper();
         if (request != null) {

--- a/src/main/java/io/gorse/gorse4j/Gorse.java
+++ b/src/main/java/io/gorse/gorse4j/Gorse.java
@@ -57,21 +57,12 @@ public class Gorse {
     }
 
     /**
-     * Get recommendation for a user.
-     * @param userId User ID
-     * @return List of recommended item IDs
-     */
-    public List<String> getRecommend(String userId) throws IOException {
-        return List.of(this.request("GET", this.endpoint + "/api/recommend/" + userId, null, String[].class));
-    }
-
-    /**
      * Get recommendation with scores for a user.
      * Uses X-API-Version: 2 header to return scores.
      * @param userId User ID
      * @return List of Score objects with item IDs and scores
      */
-    public List<Score> getRecommendWithScores(String userId) throws IOException {
+    public List<Score> getRecommend(String userId) throws IOException {
         return List.of(this.requestWithHeaders("GET", this.endpoint + "/api/recommend/" + userId, null, Score[].class, 
             Map.of("X-API-Version", "2")));
     }

--- a/src/test/java/GorseTest.java
+++ b/src/test/java/GorseTest.java
@@ -75,9 +75,9 @@ public class GorseTest {
     @Test
     public void testRecommend() throws IOException {
         client.insertUser(new User("3000", null));
-        List<String> recommendations = client.getRecommend("3000");
-        Assert.assertEquals("315", recommendations.get(0));
-        Assert.assertEquals("1432", recommendations.get(1));
-        Assert.assertEquals("918", recommendations.get(2));
+        List<Score> recommendations = client.getRecommend("3000");
+        Assert.assertEquals("315", recommendations.get(0).getId());
+        Assert.assertEquals("1432", recommendations.get(1).getId());
+        Assert.assertEquals("918", recommendations.get(2).getId());
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: getRecommend now returns List<Score> instead of List<String>

- Uses X-API-Version: 2 header to return recommendation scores
- Related: https://github.com/gorse-io/gorse/pull/1140