### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Java SDK for gorse recommender system
 <dependency>
     <groupId>io.gorse</groupId>
     <artifactId>gorse-client</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
 </dependency>
 ```
 

--- a/gorse-client/pom.xml
+++ b/gorse-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.gorse</groupId>
         <artifactId>gorse4j</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/gorse-kafka-connect/pom.xml
+++ b/gorse-kafka-connect/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.gorse</groupId>
         <artifactId>gorse4j</artifactId>
-        <version>0.5.0</version>
+        <version>0.5.1</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/gorse-kafka-connect/src/main/java/io/gorse/gorse4j/connect/GorseSinkConnector.java
+++ b/gorse-kafka-connect/src/main/java/io/gorse/gorse4j/connect/GorseSinkConnector.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class GorseSinkConnector extends SinkConnector {
 
-    static final String VERSION = "0.5.0";
+    static final String VERSION = "0.5.1";
 
     private Map<String, String> props;
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.gorse</groupId>
     <artifactId>gorse4j</artifactId>
-    <version>0.5.0</version>
+    <version>0.5.1</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
## Summary
- Bump root Maven project version to 0.5.1.
- Update child module parent versions to 0.5.1.
- Update README dependency example and Kafka connector version constant.

## Test Plan
- Started local Gorse test service using the repository's setup-test workflow dependencies.
- Ran `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 mvn --batch-mode test`.
- Ran `git diff --check`.