### PR TITLE
feat: compose Kafka Connect labels from fields

### DIFF
--- a/gorse-kafka-connect/src/main/java/io/gorse/gorse4j/connect/GorseSinkConfig.java
+++ b/gorse-kafka-connect/src/main/java/io/gorse/gorse4j/connect/GorseSinkConfig.java
@@ -2,6 +2,7 @@ package io.gorse.gorse4j.connect;
 
 import org.apache.kafka.common.config.ConfigDef;
 
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -78,6 +79,26 @@ final class GorseSinkConfig {
                 props.get("topic." + topic + ".field." + fieldName),
                 props.get("field." + fieldName),
                 defaults);
+    }
+
+    Map<String, String> labelFieldPaths(String topic) {
+        Map<String, String> fieldPaths = new LinkedHashMap<>();
+        addLabelFieldPaths(fieldPaths, "field.labels.");
+        addLabelFieldPaths(fieldPaths, "topic." + topic + ".field.labels.");
+        return fieldPaths;
+    }
+
+    private void addLabelFieldPaths(Map<String, String> fieldPaths, String prefix) {
+        for (Map.Entry<String, String> entry : props.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (key.startsWith(prefix) && value != null && !value.isBlank()) {
+                String labelName = key.substring(prefix.length());
+                if (!labelName.isBlank()) {
+                    fieldPaths.put(labelName, value);
+                }
+            }
+        }
     }
 
     private String required(String key) {

--- a/gorse-kafka-connect/src/main/java/io/gorse/gorse4j/connect/RecordMapper.java
+++ b/gorse-kafka-connect/src/main/java/io/gorse/gorse4j/connect/RecordMapper.java
@@ -78,7 +78,7 @@ final class RecordMapper {
     private User toUser(String topic, Map<String, Object> value) {
         return new User(
                 stringValue(required(value, topic, FIELD_USER_ID, DEFAULT_USER_ID_PATHS)),
-                find(value, topic, FIELD_LABELS, DEFAULT_LABELS_PATHS),
+                labels(value, topic),
                 stringValue(find(value, topic, FIELD_COMMENT, DEFAULT_COMMENT_PATHS)));
     }
 
@@ -86,7 +86,7 @@ final class RecordMapper {
         return new Item(
                 stringValue(required(value, topic, FIELD_ITEM_ID, DEFAULT_ITEM_ID_PATHS)),
                 booleanValue(find(value, topic, FIELD_IS_HIDDEN, DEFAULT_IS_HIDDEN_PATHS)),
-                find(value, topic, FIELD_LABELS, DEFAULT_LABELS_PATHS),
+                labels(value, topic),
                 stringList(find(value, topic, FIELD_CATEGORIES, DEFAULT_CATEGORIES_PATHS)),
                 stringValue(find(value, topic, FIELD_TIMESTAMP, DEFAULT_TIMESTAMP_PATHS)),
                 stringValue(find(value, topic, FIELD_COMMENT, DEFAULT_COMMENT_PATHS)));
@@ -103,8 +103,23 @@ final class RecordMapper {
                 stringValue(required(value, topic, FIELD_ITEM_ID, DEFAULT_ITEM_ID_PATHS)),
                 doubleValue(find(value, topic, FIELD_VALUE, DEFAULT_VALUE_PATHS)),
                 stringValue(find(value, topic, FIELD_TIMESTAMP, DEFAULT_TIMESTAMP_PATHS)),
-                find(value, topic, FIELD_LABELS, DEFAULT_LABELS_PATHS),
+                labels(value, topic),
                 stringValue(find(value, topic, FIELD_COMMENT, DEFAULT_COMMENT_PATHS)));
+    }
+
+    private Object labels(Map<String, Object> value, String topic) {
+        Map<String, String> labelFieldPaths = config.labelFieldPaths(topic);
+        if (labelFieldPaths.isEmpty()) {
+            return find(value, topic, FIELD_LABELS, DEFAULT_LABELS_PATHS);
+        }
+        Map<String, Object> labels = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : labelFieldPaths.entrySet()) {
+            Object labelValue = findByPaths(value, entry.getValue());
+            if (labelValue != null) {
+                labels.put(entry.getKey(), labelValue);
+            }
+        }
+        return labels.isEmpty() ? null : labels;
     }
 
     private Object required(
@@ -124,7 +139,10 @@ final class RecordMapper {
             String topic,
             String fieldName,
             String defaultPaths) {
-        String paths = config.fieldPaths(topic, fieldName, defaultPaths);
+        return findByPaths(value, config.fieldPaths(topic, fieldName, defaultPaths));
+    }
+
+    private Object findByPaths(Map<String, Object> value, String paths) {
         for (String path : paths.split(",")) {
             Object fieldValue = getPath(value, path.trim());
             if (fieldValue != null) {

--- a/gorse-kafka-connect/src/test/java/io/gorse/gorse4j/connect/RecordMapperTest.java
+++ b/gorse-kafka-connect/src/test/java/io/gorse/gorse4j/connect/RecordMapperTest.java
@@ -36,6 +36,57 @@ public class RecordMapperTest {
     }
 
     @Test
+    public void testMapUserWithComposedLabels() {
+        RecordMapper mapper = new RecordMapper(new GorseSinkConfig(Map.of(
+                "gorse.endpoint", "http://127.0.0.1:8088",
+                "gorse.api.key", "api-key",
+                "gorse.entity", "user",
+                "field.labels.country", "country",
+                "field.labels.device", "device",
+                "field.labels.source", "context.source"
+        )));
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("user_id", "u1");
+        value.put("country", "CN");
+        value.put("device", "mobile");
+        value.put("context", Map.of("source", "ads"));
+        SinkRecord record = new SinkRecord("users", 0, null, null, null, value, 1L);
+
+        List<Object> users = mapper.toGorseRecords(record);
+
+        Assert.assertEquals(1, users.size());
+        User user = (User) users.get(0);
+        Assert.assertEquals("u1", user.getUserId());
+        Assert.assertEquals(Map.of(
+                "country", "CN",
+                "device", "mobile",
+                "source", "ads"
+        ), user.getLabels());
+    }
+
+    @Test
+    public void testMapUserWithTopicComposedLabelsOverride() {
+        RecordMapper mapper = new RecordMapper(new GorseSinkConfig(Map.of(
+                "gorse.endpoint", "http://127.0.0.1:8088",
+                "gorse.api.key", "api-key",
+                "gorse.entity", "user",
+                "field.labels.source", "source",
+                "topic.users.field.labels.source", "context.source"
+        )));
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("user_id", "u1");
+        value.put("source", "global");
+        value.put("context", Map.of("source", "topic"));
+        SinkRecord record = new SinkRecord("users", 0, null, null, null, value, 1L);
+
+        List<Object> users = mapper.toGorseRecords(record);
+
+        Assert.assertEquals(1, users.size());
+        User user = (User) users.get(0);
+        Assert.assertEquals(Map.of("source", "topic"), user.getLabels());
+    }
+
+    @Test
     public void testMapFeedbackWithFieldOverrides() {
         RecordMapper mapper = new RecordMapper(new GorseSinkConfig(Map.of(
                 "gorse.endpoint", "http://127.0.0.1:8088",


### PR DESCRIPTION
## Summary
- add support for composing Kafka Connect Labels from configured record paths
- support global `field.labels.<labelName>` and topic-specific `topic.<topic>.field.labels.<labelName>` mappings
- keep existing `Labels` / `labels` fallback behavior when no composed label fields are configured

## Example
```properties
field.labels.country=country
field.labels.device=device
field.labels.source=context.source
```

## Tests
- `mvn -pl gorse-kafka-connect test`
- `mvn -pl gorse-kafka-connect -am compile`

Note: `mvn test` for the full reactor still requires a local Gorse server for existing `gorse-client` tests and fails with `Connection refused` when that service is not running.
