### PR TITLE
feat: add SearchItems API

### DIFF
--- a/gorse-client/src/main/java/io/gorse/gorse4j/Gorse.java
+++ b/gorse-client/src/main/java/io/gorse/gorse4j/Gorse.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -46,6 +48,11 @@ public class Gorse {
 
     public Item getItem(String itemId) throws IOException {
         return this.request("GET", this.endpoint + "/api/item/" + itemId, null, Item.class);
+    }
+
+    public ItemIterator searchItems(String query, int n) throws IOException {
+        String encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8);
+        return this.request("GET", this.endpoint + "/api/items?q=" + encodedQuery + "&n=" + n, null, ItemIterator.class);
     }
 
     public RowAffected deleteItem(String itemId) throws IOException {

--- a/gorse-client/src/main/java/io/gorse/gorse4j/ItemIterator.java
+++ b/gorse-client/src/main/java/io/gorse/gorse4j/ItemIterator.java
@@ -1,0 +1,43 @@
+package io.gorse.gorse4j;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+public class ItemIterator {
+
+    private String cursor;
+    private List<Item> items;
+
+    public ItemIterator() {
+    }
+
+    public ItemIterator(String cursor, List<Item> items) {
+        this.cursor = cursor;
+        this.items = items;
+    }
+
+    @JsonProperty("Cursor")
+    public String getCursor() {
+        return cursor;
+    }
+
+    @JsonProperty("Items")
+    public List<Item> getItems() {
+        return items;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ItemIterator that = (ItemIterator) o;
+        return Objects.equals(cursor, that.cursor) && Objects.equals(items, that.items);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cursor, items);
+    }
+}

--- a/gorse-client/src/test/java/GorseTest.java
+++ b/gorse-client/src/test/java/GorseTest.java
@@ -55,6 +55,14 @@ public class GorseTest {
     }
 
     @Test
+    public void testSearchItems() throws IOException {
+        ItemIterator items = client.searchItems("Toy Story", 3);
+        Assert.assertFalse(items.getItems().isEmpty());
+        Assert.assertEquals("1", items.getItems().get(0).getItemId());
+        Assert.assertEquals("Toy Story (1995)", items.getItems().get(0).getComment());
+    }
+
+    @Test
     public void testFeedback() throws IOException {
         client.insertUser(new User("2000", null));
 


### PR DESCRIPTION
## Summary
- add `ItemIterator` response model for item search results
- add `Gorse.searchItems(String query, int n)` using `/api/items?q=...&n=...`
- cover SearchItems with an integration test matching the gorse-go client behavior

## Tests
- `mvn -DskipTests -Dmaven.javadoc.skip=true package`

Note: full integration tests require a Gorse server on `127.0.0.1:8088`; without it, existing tests fail with `Connection refused`.
