### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Java SDK for gorse recommender system
 <dependency>
     <groupId>io.gorse</groupId>
     <artifactId>gorse-client</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
 </dependency>
 ```
 

--- a/gorse-client/pom.xml
+++ b/gorse-client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.gorse</groupId>
         <artifactId>gorse4j</artifactId>
-        <version>0.5.1</version>
+        <version>0.5.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/gorse-kafka-connect/pom.xml
+++ b/gorse-kafka-connect/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.gorse</groupId>
         <artifactId>gorse4j</artifactId>
-        <version>0.5.1</version>
+        <version>0.5.2</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.gorse</groupId>
     <artifactId>gorse4j</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
## Summary
- bump project version from `0.5.1` to `0.5.2`
- update module parent versions and README dependency snippet

## Tests
- `mvn -DskipTests -Dmaven.javadoc.skip=true package`
